### PR TITLE
Adding PWM2 and RWD2

### DIFF
--- a/firmware/Pic32/RFIDler.X/include/rfidler.h
+++ b/firmware/Pic32/RFIDler.X/include/rfidler.h
@@ -169,6 +169,12 @@ extern BOOL             FakeRead;                           // flag for analogue
 extern BYTE             RWD_State;                              // current state of RWD coil
 extern unsigned long    RWD_Fc;                                 // field clock in uS
 extern unsigned long    RWD_Gap_Period;                         // length of command gaps in SYSTEM ticks
+extern unsigned long    RWD_Zero_Gap_Period;			// alternately, one and zero gap lengths 
+extern unsigned long    RWD_One_Gap_Period; 
+extern unsigned long    RWD_Zero_Barrier_Period;		// periods for a byte barrier if needed	
+extern unsigned long    RWD_One_Barrier_Period; 
+extern BOOL		RWD_Barrier;				// is there a barrier
+extern BOOL		RWD_Diff;				// does gap vary for a 0 versus a 0
 extern unsigned int     RWD_Zero_Period;                        // length of '0' in OC5 ticks
 extern unsigned int     RWD_One_Period;                         // length of '1' in OC5 ticks
 extern unsigned long    RWD_Sleep_Period;                       // length of initial sleep to reset tag in system ticks
@@ -215,6 +221,12 @@ typedef struct {
     unsigned int    RWD_One_Period;
     unsigned int    RWD_Sleep_Period;
     unsigned int    RWD_Wake_Period;
+    unsigned long   RWD_Zero_Gap_Period;			// alternately, one and zero gap lengths 
+    unsigned long   RWD_One_Gap_Period; 
+    unsigned long   RWD_Barrier_Zero_Period;		// periods for a byte barrier if needed	
+    unsigned long   RWD_Barrier_One_Period; 
+    BOOL	    RWD_Barrier;				// is there a barrier
+    BOOL	    RWD_Diff;				// does gap vary for a 0 versus a 0
     unsigned int    RWD_Wait_Switch_TX_RX;
     unsigned int    RWD_Wait_Switch_RX_TX;
 } StoredConfig;
@@ -269,9 +281,12 @@ extern rtccDate	RTC_date;			// date structure
 #define                 RWD_STATE_GO_TO_SLEEP           1       // RWD coil shutdown request
 #define                 RWD_STATE_WAKING                2       // RWD active for pre-determined period after reset
 #define                 RWD_STATE_START_SEND            3       // RWD start send of data
-#define                 RWD_STATE_SENDING_BIT           4       // RWD sending a data bit & gap
+#define                 RWD_STATE_SENDING_BIT_HIGH      4       // RWD sending a data bit & gap
+#define                 RWD_STATE_SENDING_BIT_LOW       7       // RWD sending a data bit & gap
 #define                 RWD_STATE_POST_WAIT             5       // RWD finished sending data, now in forced wait period
 #define                 RWD_STATE_ACTIVE                6       // RWD finished, now just clocking a carrier
+#define                 RWD_STATE_SENDING_BARRIER_HIGH  8       // RWD barrier high
+#define                 RWD_STATE_SENDING_BARRIER_LOW   9       // RWD barrier low
 
 // reader ISR states
 #define                 READER_STOPPED                  0       // reader not in use

--- a/firmware/Pic32/RFIDler.X/include/rfidler.h
+++ b/firmware/Pic32/RFIDler.X/include/rfidler.h
@@ -142,7 +142,7 @@
 #define TMP_SMALL_BUFF_LEN  256
 #define ANALOGUE_BUFF_LEN   8192
 
-#define COMMS_BUFFER_SIZE   128
+#define COMMS_BUFFER_SIZE   256
 
 #define SAMPLEMASK          ~(BIT_1 | BIT_0)    // mask to remove two bottom bits from analogue sample - we will then use those for reader & bit period
 

--- a/firmware/Pic32/RFIDler.X/src/isr.c
+++ b/firmware/Pic32/RFIDler.X/src/isr.c
@@ -152,6 +152,7 @@ BOOL Manchester_Auto_Correct= FALSE; // this will be reset by reader ISR if set.
 void __ISR(_OUTPUT_COMPARE_5_VECTOR, ipl6auto) reader_clock_tick (void)
 {
     static unsigned int count= 0;
+    static unsigned int bcount= 0;
 
     // Clear interrupt flag
     mOC5ClearIntFlag();
@@ -207,47 +208,69 @@ void __ISR(_OUTPUT_COMPARE_5_VECTOR, ipl6auto) reader_clock_tick (void)
             // send initial gap
             // stop modulation of coil and wait
             READER_CLOCK_ENABLE_OFF();
-            // time small amounts with ticks, large with uS
-            if(RWD_Gap_Period > MAX_TIMER5_TICKS)
-                Delay_us(CONVERT_TICKS_TO_US(RWD_Gap_Period));
-            else
-            {
-                WriteTimer5(0);
-                while(GetTimer_ticks(NO_RESET) < RWD_Gap_Period)
-                    ;
-            }
             count= 0;
-            RWD_State= RWD_STATE_SENDING_BIT;
+            RWD_State= RWD_STATE_SENDING_BIT_LOW;
             //DEBUG_PIN_4= !DEBUG_PIN_4;
             // restart clock
             READER_CLOCK_ENABLE_ON();
             break;
 
-        case RWD_STATE_SENDING_BIT:
+        case RWD_STATE_SENDING_BIT_HIGH:
             //DEBUG_PIN_4= !DEBUG_PIN_4;
             // clock running for bit period, then wait for gap period
             if((*RWD_Command_ThisBit && count == RWD_One_Period) || (!*RWD_Command_ThisBit && count == RWD_Zero_Period))
-            {
-                // stop modulation of coil and wait
-                READER_CLOCK_ENABLE_OFF();
-                if(RWD_Gap_Period > MAX_TIMER5_TICKS)
-                    Delay_us(CONVERT_TICKS_TO_US(RWD_Gap_Period));
-                else
-                {
-                    WriteTimer5(0);
-                    while(GetTimer_ticks(NO_RESET) < RWD_Gap_Period)
-                        ;
-                }
-                ++RWD_Command_ThisBit;
-                count= 0;
+            {                    
+		count= 0;
                 if(*RWD_Command_ThisBit == '*')
                     RWD_State= RWD_STATE_POST_WAIT;
+		else if(RWD_Barrier && bcount == 0)
+		    RWD_State= RWD_STATE_SENDING_BARRIER_LOW;
                 else
-                    RWD_State= RWD_STATE_SENDING_BIT;
+                    RWD_State= RWD_STATE_SENDING_BIT_LOW;
+		READER_CLOCK_ENABLE_OFF();
+                bcount++;
+                if(bcount == 8)
+                   bcount = 0;
+		          
+            }
+            else
+                count++;
+            break;
+
+	case RWD_STATE_SENDING_BIT_LOW:
+
+            if((*RWD_Command_ThisBit && count == RWD_One_Gap_Period) || (!*RWD_Command_ThisBit && count == RWD_Zero_Gap_Period))
+            {
+		
+                ++RWD_Command_ThisBit;
+                count= 0;
+
+                RWD_State= RWD_STATE_SENDING_BIT_HIGH;
                 // restart clock
+
                READER_CLOCK_ENABLE_ON();
             }
             else
+                count++;
+            break;
+
+	case RWD_STATE_SENDING_BARRIER_HIGH:
+
+            if(count == RWD_One_Barrier_Period){
+                count= 0;
+                RWD_State= RWD_STATE_SENDING_BIT_LOW;
+		READER_CLOCK_ENABLE_OFF();
+	    }else
+                count++;
+            break;
+
+	case RWD_STATE_SENDING_BARRIER_LOW:
+
+            if(count == RWD_Zero_Barrier_Period){
+                count= 0;
+                RWD_State= RWD_STATE_SENDING_BARRIER_HIGH;
+		READER_CLOCK_ENABLE_ON();
+	    }else
                 count++;
             break;
 

--- a/firmware/Pic32/RFIDler.X/src/main.c
+++ b/firmware/Pic32/RFIDler.X/src/main.c
@@ -2193,11 +2193,13 @@ BYTE ProcessSerialCommand(char *command)
             UserMessage("%s", "    PSK1 <HEX UID> <FC> <RATE> <SUB> <REPEAT>                    Emulate PSK1, Field Clock in uS/100, Data Rate in RF/n,\r\n");
             UserMessage("%s", "                                                                 Sub Carrier in RF/n\r\n");
             UserMessage("%s", "    PWM <FC> <SLEEP> <WAKE> <PW0> <PW1> <GAP> <TXRX> <RXTX>      Set PWM parameters for RWD commands, Field Clock in uS/100, timings in FCs\r\n");
+            UserMessage("%s", "    PWM2 <FC> <SLEEP> <WAKE> <PW0> <PW1> <GAP> <TXRX> <RXTX> <DIFF> <GAP1> <GAP0> <BARRIER> <B1> <B0>     Set  advanced PWM parameters for RWD commands, Field Clock in uS/100, timings in FCs\r\n");
             UserMessage("%s", "    READ <START BLOCK> [END BLOCK]                               Read and store data block(s) (may require auth/login)\r\n");
             UserMessage("%s", "    READER                                                       Go into READER mode (continuously acquire UID)\r\n");
             UserMessage("%s", "    REBOOT                                                       Perform soft reset\r\n");
             UserMessage("%s", "    RTC                                                          Show Real Time Clock\r\n");
-            UserMessage("%s", "    RWD <BINARY>                                                 Send binary command/data\r\n");
+            UserMessage("%s", "    RWD <BINARY>                                                 Send binary command/data set with PWM\r\n");
+            UserMessage("%s", "    RWD2 <BINARY>                                                Send binary command/data set with PWM 2\r\n");
             UserMessage("%s", "    SAVE                                                         Save current config to NVM\r\n");
             UserMessage("%s", "    SELECT [UID]                                                 Send SELECT command\r\n");
             UserMessage("%s", "    SET BIPHASE <ON|OFF>                                         Set BiPhase encoding\r\n");

--- a/firmware/Pic32/RFIDler.X/src/main.c
+++ b/firmware/Pic32/RFIDler.X/src/main.c
@@ -1488,13 +1488,13 @@ BYTE ProcessSerialCommand(char *command)
 
     if (strncmp(command, "PWM2 ", 4) == 0)
     {
-        if(sscanf(command + 4,"%u %u %u %u %u %u %u %u %u %u %u %u %u %u", &tmpint, &tmpint1, &tmpint2, &tmpint3, &tmpint4, &tmpint5, &tmpint6, &tmpint7, &tmpint8, &tmpint9, &tmpint10, &tmpint11, &tmpint12, &tmpint13) == 8)
+        if(sscanf(command + 4,"%u %u %u %u %u %u %u %u %u %u %u %u %u %u", &tmpint, &tmpint1, &tmpint2, &tmpint3, &tmpint4, &tmpint5, &tmpint6, &tmpint7, &tmpint8, &tmpint9, &tmpint10, &tmpint11, &tmpint12, &tmpint13) == 14)
         {
             rwd_set_pwm2(tmpint, tmpint1, tmpint2, tmpint3, tmpint4, tmpint5, tmpint6, tmpint7, tmpint8, tmpint9, tmpint10, tmpint11, tmpint12, tmpint13);
             commandok= command_ack(NO_DATA);
         }
         else
-            commandok= command_nack("Invalid parameters!");
+            commandok= command_nack("Invalid parameters 2 !");
     }
 
 

--- a/firmware/Pic32/RFIDler.X/src/rwd.c
+++ b/firmware/Pic32/RFIDler.X/src/rwd.c
@@ -145,6 +145,8 @@ void rwd_set_pwm(unsigned long fc, unsigned long sleep, unsigned int wake, unsig
     RFIDlerConfig.RWD_Zero_Period= pw0;
     RFIDlerConfig.RWD_One_Period= pw1;
     RFIDlerConfig.RWD_Gap_Period= gap;
+    RFIDlerConfig.RWD_One_Gap_Period= gap;
+    RFIDlerConfig.RWD_Zero_Gap_Period= gap;
     RFIDlerConfig.RWD_Wait_Switch_TX_RX= wait_txrx;
     RFIDlerConfig.RWD_Wait_Switch_RX_TX= wait_rxtx;
 }
@@ -155,7 +157,9 @@ BOOL rwd_send(unsigned char *command, unsigned int length, BOOL reset, BOOL bloc
     RWD_Fc= fc;
     // convert FCs to system ticks
     RWD_Sleep_Period= CONVERT_TO_TICKS(sleep * fc);
-    RWD_Gap_Period= CONVERT_TO_TICKS(gap * fc);
+    RWD_Gap_Period= gap * 2;
+    RWD_One_Gap_Period= gap * 2;
+    RWD_Zero_Gap_Period= gap * 2;
     // convert FCs to OCM ticks
     RWD_Wake_Period= wake * 2;
     RWD_Zero_Period= pw0 * 2;


### PR DESCRIPTION
Adding two commands, PWM2 and RWD2 that allow additional settings in PWM. The gap can now be set so that it different between a one and zero, and a waveform between bytes can be added.

I also increased the comms buffer size from 128 to 256, as it was too small to hold the bit string for my application.

Note that this patch is not particularly well tested as I don't have any tags. 