### PR TITLE
Fix password mode for T55X7

### DIFF
--- a/firmware/Pic32/RFIDler.X/src/t55x7.c
+++ b/firmware/Pic32/RFIDler.X/src/t55x7.c
@@ -198,25 +198,32 @@ BOOL t55x7_get_uid(BYTE *response)
 
 BOOL t55x7_read_block(BYTE *response, BYTE block)
 {
-    BYTE tmp[39], retry, reset= FALSE;
+    BYTE tmp[39], p, retry, reset= FALSE;
 
     if(block > T55X7_DATABLOCKS - 1)
         return FALSE;
 
-    // create 6 or 38 bit command block: Q5_DIRECT_ACCESS + PWD_Mode + [PWD] + 3 bits address
-    memset(tmp, '\0', 39);
+    // create 6 or 38 bit command block: T55X7_DIRECT_ACCESS + [PWD] + single '0' + 3 bits address
+    memset(tmp, '\0', sizeof(tmp));
+
+    // command
     memcpy(tmp, T55X7_DIRECT_ACCESS, 2);
+    p = 2;
+
+    // password
     if(PWD_Mode)
     {
-        tmp[2]= '1';
-        hextobinstring(tmp + 3, Password);
-        inttobinstring(tmp + 34, (unsigned int) block, 3);
+        hextobinstring(tmp + p, Password);
+        p += 32;
     }
-    else
-    {
-        tmp[2]= '0';
-        inttobinstring(tmp + 3, (unsigned int) block, 3);
-    }
+
+    // single '0'
+    tmp[p]= '0';
+    ++p;
+
+    // address
+    inttobinstring(tmp + p, (unsigned int) block, 3);
+    p += 3;
 
     retry= RFIDlerConfig.Repeat;
     while(retry--)


### PR DESCRIPTION
Hi guys,
this is a fix for reading blocks of a T55X7 tag with password mode enabled.
The password comes right after the opcode (2bits), if enabled.
See also the T55X7 documentation.

Regards,
Stefan