### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # RFIDler
 
 
-##Firmware
+## Firmware
 
 The 'firmware' directory contains code for the dev platform(s).
 Currently that is Pic32, but we will add a new section if and when required.
 
-##Hardware
+## Hardware
 
 A fully built RFIDler board can be purchased here: [http://aperturelabs.com/tools.html](http://aperturelabs.com/tools.html)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
