### PR TITLE
Microsoft usb descriptors for auto device install (win 7, 8.0, 8.1)

### DIFF
--- a/firmware/Pic32/RFIDler.X/include/rfidler.h
+++ b/firmware/Pic32/RFIDler.X/include/rfidler.h
@@ -131,6 +131,7 @@
 
 
 // BCD hardware/product revision for usb descriptor (usb_descriptors.c)
+// 0x20 - first version shipped, 0x21 - version with Microsoft OS USB descriptors
 #define RFIDLER_HW_VERSION        0x021
 
 // max sizes in BITS

--- a/firmware/Pic32/RFIDler.X/include/rfidler.h
+++ b/firmware/Pic32/RFIDler.X/include/rfidler.h
@@ -130,8 +130,8 @@
 // Author: Adam Laurie <adam@aperturelabs.com>
 
 
-// BCD hardware revision for usb descriptor (usb_descriptors.c)
-#define RFIDLER_HW_VERSION        0x020
+// BCD hardware/product revision for usb descriptor (usb_descriptors.c)
+#define RFIDLER_HW_VERSION        0x021
 
 // max sizes in BITS
 #define MAXBLOCKSIZE        512

--- a/firmware/Pic32/RFIDler.X/include/usb_config.h
+++ b/firmware/Pic32/RFIDler.X/include/usb_config.h
@@ -95,6 +95,44 @@
 #define USB_SPEED_OPTION USB_FULL_SPEED
 //#define USB_SPEED_OPTION USB_LOW_SPEED //(not valid option for PIC24F devices)
 
+
+//When implemented, the Microsoft OS Descriptor allows the WinUSB driver package
+//installation to be automatic on Windows 8, and is therefore recommended.
+#define IMPLEMENT_MICROSOFT_OS_DESCRIPTOR
+
+//Some definitions, only needed when using the MS OS descriptor.
+#if defined(IMPLEMENT_MICROSOFT_OS_DESCRIPTOR)
+    #define MICROSOFT_OS_DESCRIPTOR_INDEX   (unsigned char)0xEE //Magic string index number for the Microsoft OS descriptor
+    #define GET_MS_DESCRIPTOR               (unsigned char)0x2A //(arbitarily assigned, but should not clobber/overlap normal bRequests)
+                                                                // Vendor Code, arbitrary non-zero value chosen once by vendor, DO NOT CHANGE as cached by Windows
+    #define EXTENDED_COMPAT_ID              (WORD)0x0004
+    #define EXTENDED_PROPERTIES             (WORD)0x0005
+    typedef struct __attribute__ ((packed)) _MS_OS_DESCRIPTOR{BYTE bLength;BYTE bDscType;WORD string[7];BYTE vendorCode;BYTE bPad;}MS_OS_DESCRIPTOR;
+    typedef struct __attribute__ ((packed)) _MS_COMPAT_ID_FEATURE_DESC{DWORD dwLength;WORD bcdVersion;WORD wIndex;BYTE bCount;BYTE Reserved[7];BYTE bFirstInterfaceNumber;BYTE Reserved1;BYTE compatID[8];BYTE subCompatID[8];BYTE Reserved2[6];}MS_COMPAT_ID_FEATURE_DESC;
+// 1 2 or 3
+#define MS_FEATURES 1
+#if (MS_FEATURES == 3)
+#define MS_FEATURE2
+#define MS_FEATURE3
+#elif (MS_FEATURES == 2)
+#define MS_FEATURE2
+#endif
+    // Note below structure edited for RFIDler to have 3 features, Note character array sizes must match the Unicode string lenghts!
+    typedef struct __attribute__ ((packed)) _MS_EXT_PROPERTY_FEATURE_DESC{DWORD dwLength;WORD bcdVersion;WORD wIndex;WORD wCount;
+        DWORD dwSize1;DWORD dwPropertyDataType1;WORD wPropertyNameLength1;WORD bPropertyName1[20];DWORD dwPropertyDataLength1;WORD bPropertyData1[39];
+#if defined(MS_FEATURE2)
+        DWORD dwSize2;DWORD dwPropertyDataType2;WORD wPropertyNameLength2;WORD bPropertyName2[6];DWORD dwPropertyDataLength2;WORD bPropertyData2[11];
+#endif
+#if defined(MS_FEATURE3)
+        DWORD dwSize3;DWORD dwPropertyDataType3;WORD wPropertyNameLength3;WORD bPropertyName3[6];DWORD dwPropertyDataLength3;WORD bPropertyData3[38];
+#endif
+        }MS_EXT_PROPERTY_FEATURE_DESC;
+    extern ROM MS_OS_DESCRIPTOR MSOSDescriptor;
+    extern ROM MS_COMPAT_ID_FEATURE_DESC CompatIDFeatureDescriptor;
+    extern ROM MS_EXT_PROPERTY_FEATURE_DESC ExtPropertyFeatureDescriptor;
+#endif
+
+
 #define USB_SUPPORT_DEVICE
 
 #define USB_NUM_STRING_DESCRIPTORS 4

--- a/firmware/Pic32/RFIDler.X/include/usb_config.h
+++ b/firmware/Pic32/RFIDler.X/include/usb_config.h
@@ -98,10 +98,7 @@
 
 //When implemented, the Microsoft OS Descriptor allows the WinUSB driver package
 //installation to be automatic on Windows 8, and is therefore recommended.
-#define IMPLEMENT_MICROSOFT_OS_DESCRIPTOR
 
-//Some definitions, only needed when using the MS OS descriptor.
-#if defined(IMPLEMENT_MICROSOFT_OS_DESCRIPTOR)
     #define MICROSOFT_OS_DESCRIPTOR_INDEX   (unsigned char)0xEE //Magic string index number for the Microsoft OS descriptor
     #define GET_MS_DESCRIPTOR               (unsigned char)0x2A //(arbitarily assigned, but should not clobber/overlap normal bRequests)
                                                                 // Vendor Code, arbitrary non-zero value chosen once by vendor, DO NOT CHANGE as cached by Windows
@@ -109,28 +106,15 @@
     #define EXTENDED_PROPERTIES             (WORD)0x0005
     typedef struct __attribute__ ((packed)) _MS_OS_DESCRIPTOR{BYTE bLength;BYTE bDscType;WORD string[7];BYTE vendorCode;BYTE bPad;}MS_OS_DESCRIPTOR;
     typedef struct __attribute__ ((packed)) _MS_COMPAT_ID_FEATURE_DESC{DWORD dwLength;WORD bcdVersion;WORD wIndex;BYTE bCount;BYTE Reserved[7];BYTE bFirstInterfaceNumber;BYTE Reserved1;BYTE compatID[8];BYTE subCompatID[8];BYTE Reserved2[6];}MS_COMPAT_ID_FEATURE_DESC;
-// 1 2 or 3
-#define MS_FEATURES 1
-#if (MS_FEATURES == 3)
-#define MS_FEATURE2
-#define MS_FEATURE3
-#elif (MS_FEATURES == 2)
-#define MS_FEATURE2
-#endif
     // Note below structure edited for RFIDler to have 3 features, Note character array sizes must match the Unicode string lenghts!
     typedef struct __attribute__ ((packed)) _MS_EXT_PROPERTY_FEATURE_DESC{DWORD dwLength;WORD bcdVersion;WORD wIndex;WORD wCount;
         DWORD dwSize1;DWORD dwPropertyDataType1;WORD wPropertyNameLength1;WORD bPropertyName1[20];DWORD dwPropertyDataLength1;WORD bPropertyData1[39];
-#if defined(MS_FEATURE2)
         DWORD dwSize2;DWORD dwPropertyDataType2;WORD wPropertyNameLength2;WORD bPropertyName2[6];DWORD dwPropertyDataLength2;WORD bPropertyData2[11];
-#endif
-#if defined(MS_FEATURE3)
         DWORD dwSize3;DWORD dwPropertyDataType3;WORD wPropertyNameLength3;WORD bPropertyName3[6];DWORD dwPropertyDataLength3;WORD bPropertyData3[38];
-#endif
         }MS_EXT_PROPERTY_FEATURE_DESC;
     extern ROM MS_OS_DESCRIPTOR MSOSDescriptor;
     extern ROM MS_COMPAT_ID_FEATURE_DESC CompatIDFeatureDescriptor;
     extern ROM MS_EXT_PROPERTY_FEATURE_DESC ExtPropertyFeatureDescriptor;
-#endif
 
 
 #define USB_SUPPORT_DEVICE

--- a/firmware/Pic32/RFIDler.X/src/main.c
+++ b/firmware/Pic32/RFIDler.X/src/main.c
@@ -551,7 +551,7 @@ BYTE ProcessIO(void)
     CDCTxService();
 }		//end ProcessIO
 
-// USBCheckVendorRequest() function is from Microchip USB Library for Applications dated 2013-12-20
+// USBCheckVendorRequest() function is taken from usb_generic_device.c in Microchip USB Library for Applications dated 2013-12-20
 /********************************************************************
 	Function:
 		void USBCheckVendorRequest(void)

--- a/firmware/Pic32/RFIDler.X/src/usb_descriptors.c
+++ b/firmware/Pic32/RFIDler.X/src/usb_descriptors.c
@@ -307,6 +307,98 @@ ROM BYTE *ROM USB_SD_Ptr[USB_NUM_STRING_DESCRIPTORS]=
     (ROM BYTE *ROM)&sd003
 };
 
+#if 1
+    /*
+        MS_OS_DESCRIPTOR, MS_COMPAT_ID_FEATURE_DESC and MS_EXT_PROPERTY_FEATURE_DESC
+        are defined in Microchip's USB Library for Applications dated 2013/12/20
+        Adapted for RFIDler-LF in July 2017.
+        Note: if string text is changed ensure usb_config.h string lengths are updated too!
+    */
+
+//defined(IMPLEMENT_MICROSOFT_OS_DESCRIPTOR)
+    //Microsoft "OS Descriptor" - This descriptor is based on a Microsoft specific
+    //specification (not part of the standard USB 2.0 specs or class specs).
+    //Implementing this special descriptor allows WinUSB driver package installation
+    //to be automatic on Windows 8.  For additional details, see:
+    //http://msdn.microsoft.com/en-us/library/windows/hardware/hh450799(v=vs.85).aspx
+    const MS_OS_DESCRIPTOR MSOSDescriptor =
+    {
+        sizeof(MSOSDescriptor),         //bLength - lenght of this descriptor in bytes
+        USB_DESCRIPTOR_STRING,          //bDescriptorType - "string"
+        {'M','S','F','T','1','0','0'},  //qwSignature - special values that specifies the OS descriptor spec version that this firmware implements
+        GET_MS_DESCRIPTOR,              //bMS_VendorCode - defines the "GET_MS_DESCRIPTOR" bRequest literal value
+        0x00                            //bPad - always 0x00
+    };
+
+
+    //Extended Compat ID OS Feature Descriptor
+    const MS_COMPAT_ID_FEATURE_DESC CompatIDFeatureDescriptor =
+    {
+        //----------Header Section--------------
+        sizeof(CompatIDFeatureDescriptor),  //dwLength
+        0x0100,                             //bcdVersion = 1.00
+        EXTENDED_COMPAT_ID,                 //wIndex
+        0x01,                               //bCount - 0x01 "Function Section(s)" implemented in this descriptor
+        {0,0,0,0,0,0,0},                    //Reserved[7]
+        //----------Function Section 1----------
+        0x00,                               //bFirstInterfaceNumber: the WinUSB interface in this firmware is interface #0
+        0x01,                               //Reserved - fill this reserved byte with 0x01 according to documentation
+        {'W','I','N','U','S','B',0x00,0x00},//compatID - "WINUSB" (with two null terminators to fill all 8 bytes)
+        {0,0,0,0,0,0,0,0},                  //subCompatID - eight bytes of 0
+        {0,0,0,0,0,0}                       //Reserved
+    };
+
+
+    //Extended Properties OS Feature Descriptor
+    const MS_EXT_PROPERTY_FEATURE_DESC ExtPropertyFeatureDescriptor =
+    {
+        //----------Header Section--------------
+        sizeof(ExtPropertyFeatureDescriptor),   //dwLength
+        0x0100,                                 //bcdVersion = 1.00
+        EXTENDED_PROPERTIES,                    //wIndex
+        MS_FEATURES,                            //wCount - 0x0001 "Property Sections" implemented in this descriptor
+        //----------Property Section 1----------
+        132,                                    //dwSize - 132 bytes in this Property Section
+        0x00000001,                             //dwPropertyDataType (Unicode string)
+        40,                                     //wPropertyNameLength - 40 bytes in the bPropertyName field
+        {'D','e','v','i','c','e','I','n','t','e','r','f','a','c','e','G','U','I','D', 0x0000},  //bPropertyName - "DeviceInterfaceGUID"
+        78,                                     //dwPropertyDataLength - 78 bytes in the bPropertyData field (GUID value in UNICODE formatted string, with braces and dashes)
+        //The below value is the Device Interface GUID (a 128-bit long "globally unique identifier")
+        //Please modify the GUID value in your application before moving to production.
+        //When you change the GUID, you must also change the PC application software
+        //that connects to this device, as the software looks for the device based on
+        //VID, PID, and GUID.  All three values in the PC application must match
+        //the values in this firmware.
+        //The GUID value can be a randomly generated 128-bit hexadecimal number,
+        //formatted like the below value.  The actual value is not important,
+        //so long as it is almost certain to be globally unique, and matches the
+        //PC software that communicates with this firmware.
+        //*HACK* instead of generating unique GUID we use standard GUID for COM & LPT ports
+        //= '{4d36e978-e325-11ce-bfc1-08002be10318}' to get installed as a COM port
+        {'{','4','d','3','6','e','9','7','8','-','e','3','2','5','-','1','1','c','e','-','b','f','c','1','-','0','8','0','0','2','b','e','1','0','3','1','8','}',0x0000},  //bPropertyData - this is the actual GUID value.  Make sure this matches the PC application code trying to connect to the device.
+#if defined(MS_FEATURE2)
+        //----------Property Section 2----------
+        14 + 12 + 22,                           //dwSize - 14 bytes + 2 nul terminated Unicode strings in this Property Section
+        0x00000001,                             //dwPropertyDataType (Unicode string)
+        12,                                     //wPropertyNameLength - 12 bytes in the bPropertyName field
+        {'L','a','b','e','l', 0x0000},          //bPropertyName - "Label"
+        22,                                     //dwPropertyDataLength - 22 bytes in the bPropertyData field
+                                                //bPropertyData - device label = "RFIDler-LF"
+        {'R','F','I','D','l','e','r','-','L','F',0x0000},
+#endif
+#if defined(MS_FEATURE3)
+        //----------Property Section 3----------
+        14 + 12 + 76,                           //dwSize - 14 bytes + 2 nul terminated Unicode strings in this Property Section
+        0x00000002,                             //dwPropertyDataType (Unicode string with environment variables)
+        12,                                     //wPropertyNameLength - 12 bytes in the bPropertyName field
+        {'I','c','o','n','s', 0x0000},          //bPropertyName - "Icons"
+        76,                                     //dwPropertyDataLength - 22 bytes in the bPropertyData field
+                                                //bPropertyData - "%SystemRoot%\\system32\\Shell32.dll,-13"
+        {'%','S','y','s','t','e','m','R','o','o','t','%','\\','s','y','s','t','e','m','3','2','\\','S','h','e','l','l','3','2','.','d','l','l',',','-','1','3',0x0000}
+#endif
+    };
+#endif
+
 #pragma code
 
 // Read device's unique Ethernet MAC Address, use for USB serial number

--- a/firmware/Pic32/RFIDler.X/src/usb_descriptors.c
+++ b/firmware/Pic32/RFIDler.X/src/usb_descriptors.c
@@ -307,15 +307,13 @@ ROM BYTE *ROM USB_SD_Ptr[USB_NUM_STRING_DESCRIPTORS]=
     (ROM BYTE *ROM)&sd003
 };
 
-#if 1
     /*
         MS_OS_DESCRIPTOR, MS_COMPAT_ID_FEATURE_DESC and MS_EXT_PROPERTY_FEATURE_DESC
-        are defined in Microchip's USB Library for Applications dated 2013/12/20
+        are defined in Microchip's USB Library for Applications dated 2013-12-20
         Adapted for RFIDler-LF in July 2017.
         Note: if string text is changed ensure usb_config.h string lengths are updated too!
     */
 
-//defined(IMPLEMENT_MICROSOFT_OS_DESCRIPTOR)
     //Microsoft "OS Descriptor" - This descriptor is based on a Microsoft specific
     //specification (not part of the standard USB 2.0 specs or class specs).
     //Implementing this special descriptor allows WinUSB driver package installation
@@ -356,7 +354,7 @@ ROM BYTE *ROM USB_SD_Ptr[USB_NUM_STRING_DESCRIPTORS]=
         sizeof(ExtPropertyFeatureDescriptor),   //dwLength
         0x0100,                                 //bcdVersion = 1.00
         EXTENDED_PROPERTIES,                    //wIndex
-        MS_FEATURES,                            //wCount - 0x0001 "Property Sections" implemented in this descriptor
+        3,                                      //wCount - 0x0001 "Property Sections" implemented in this descriptor
         //----------Property Section 1----------
         132,                                    //dwSize - 132 bytes in this Property Section
         0x00000001,                             //dwPropertyDataType (Unicode string)
@@ -376,7 +374,6 @@ ROM BYTE *ROM USB_SD_Ptr[USB_NUM_STRING_DESCRIPTORS]=
         //*HACK* instead of generating unique GUID we use standard GUID for COM & LPT ports
         //= '{4d36e978-e325-11ce-bfc1-08002be10318}' to get installed as a COM port
         {'{','4','d','3','6','e','9','7','8','-','e','3','2','5','-','1','1','c','e','-','b','f','c','1','-','0','8','0','0','2','b','e','1','0','3','1','8','}',0x0000},  //bPropertyData - this is the actual GUID value.  Make sure this matches the PC application code trying to connect to the device.
-#if defined(MS_FEATURE2)
         //----------Property Section 2----------
         14 + 12 + 22,                           //dwSize - 14 bytes + 2 nul terminated Unicode strings in this Property Section
         0x00000001,                             //dwPropertyDataType (Unicode string)
@@ -385,8 +382,6 @@ ROM BYTE *ROM USB_SD_Ptr[USB_NUM_STRING_DESCRIPTORS]=
         22,                                     //dwPropertyDataLength - 22 bytes in the bPropertyData field
                                                 //bPropertyData - device label = "RFIDler-LF"
         {'R','F','I','D','l','e','r','-','L','F',0x0000},
-#endif
-#if defined(MS_FEATURE3)
         //----------Property Section 3----------
         14 + 12 + 76,                           //dwSize - 14 bytes + 2 nul terminated Unicode strings in this Property Section
         0x00000002,                             //dwPropertyDataType (Unicode string with environment variables)
@@ -395,9 +390,7 @@ ROM BYTE *ROM USB_SD_Ptr[USB_NUM_STRING_DESCRIPTORS]=
         76,                                     //dwPropertyDataLength - 22 bytes in the bPropertyData field
                                                 //bPropertyData - "%SystemRoot%\\system32\\Shell32.dll,-13"
         {'%','S','y','s','t','e','m','R','o','o','t','%','\\','s','y','s','t','e','m','3','2','\\','S','h','e','l','l','3','2','.','d','l','l',',','-','1','3',0x0000}
-#endif
     };
-#endif
 
 #pragma code
 


### PR DESCRIPTION
Add USB descriptors per "Microsoft OS Descriptors", these should allow the RFIDler-LF to automatically install on Windows 7, 8.0 and 8.1 without needing the .inf install files.
(Windows 10 should recognise the original device as a serial port from the USB descriptors, and automatically install port. But Microsoft has never shipped this capability to Windows 7, or 8.x.)

Note changes the RFIDler-LF hardware version reported to the USB host, to force Windows to read the new device descriptors. (If older firmware had been connected previously then Windows caches the detail that the extra descriptors were missing.)